### PR TITLE
Option 을 entity로 변경

### DIFF
--- a/src/main/java/com/godsang/anytimedelivery/menu/controller/MenuController.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/controller/MenuController.java
@@ -34,11 +34,8 @@ public class MenuController {
   @PostMapping
   public ResponseEntity postMenu(@PathVariable("store-id") @Positive long storeId,
                                  @RequestBody @Valid MenuDto.Post menuDto) {
-    Menu menu = menuMapper.menuDtoToMenu(menuDto);
-    for (GroupDto.Post groupDto : menuDto.getGroups()) {
-      Group group = menuMapper.groupDtoToGroup(groupDto);
-      menu = menuService.createMenu(storeId, menu, group);
-    }
+    Menu menu = menuMapper.bidirectionalMapping((menuMapper.menuDtoToMenu(menuDto)));
+    menu = menuService.createMenu(storeId, menu);
     return new ResponseEntity<>(new SingleResponseDto<>(menuMapper.menuToMenuDto(menu)), HttpStatus.CREATED);
   }
 }

--- a/src/main/java/com/godsang/anytimedelivery/menu/dto/GroupDto.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/dto/GroupDto.java
@@ -15,7 +15,7 @@ public class GroupDto {
     private String title;
     @Pattern(regexp = "^(check|radio)$", message = "check 또는 radio 중 하나를 입력해야 합니다.")
     private String choiceType;
-    private List<OptionDto> options;
+    private List<OptionDto.Post> options;
   }
 
   @Getter
@@ -24,6 +24,6 @@ public class GroupDto {
     private long groupId;
     private String title;
     private String choiceType;
-    private List<OptionDto> options;
+    private List<OptionDto.Response> options;
   }
 }

--- a/src/main/java/com/godsang/anytimedelivery/menu/dto/OptionDto.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/dto/OptionDto.java
@@ -5,6 +5,17 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class OptionDto extends CommonMenuDto {
+public class OptionDto {
+  @Getter
+  @Setter
+  public static class Post extends CommonMenuDto{
+
+  }
+
+  @Getter
+  @Setter
+  public static class Response extends CommonMenuDto{
+    Long optionId;
+  }
 
 }

--- a/src/main/java/com/godsang/anytimedelivery/menu/dto/OptionDto.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/dto/OptionDto.java
@@ -3,8 +3,6 @@ package com.godsang.anytimedelivery.menu.dto;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
 public class OptionDto {
   @Getter
   @Setter

--- a/src/main/java/com/godsang/anytimedelivery/menu/entity/Group.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/entity/Group.java
@@ -6,16 +6,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.CollectionTable;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
-import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,10 +31,9 @@ public class Group {
   private String title;
   @Column(nullable = false)
   private String choiceType;
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
   private Menu menu;
-  @ElementCollection
-  @CollectionTable(name = "options", joinColumns = @JoinColumn(name = "group_id"))
+  @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Option> options = new ArrayList<>();
 
   @Builder

--- a/src/main/java/com/godsang/anytimedelivery/menu/entity/Menu.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/entity/Menu.java
@@ -33,7 +33,7 @@ public class Menu {
   private int price;
   private String description;
   private String photo;
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
   private Store store;
   @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Group> groups = new ArrayList<>();

--- a/src/main/java/com/godsang/anytimedelivery/menu/entity/Menu.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/entity/Menu.java
@@ -43,10 +43,11 @@ public class Menu {
   }
 
   @Builder
-  private Menu(String name, int price, String description, String photo) {
+  private Menu(String name, int price, String description, String photo, List<Group> groups) {
     this.name = name;
     this.price = price;
     this.description = description;
     this.photo = photo;
+    this.groups = groups;
   }
 }

--- a/src/main/java/com/godsang/anytimedelivery/menu/entity/Option.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/entity/Option.java
@@ -18,7 +18,7 @@ import javax.persistence.ManyToOne;
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "OPTIONZ") // option, options는 에약어
+@Entity(name = "OPTIONZ")
 public class Option {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/godsang/anytimedelivery/menu/entity/Option.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/entity/Option.java
@@ -6,19 +6,35 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.Embeddable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Embeddable
+@Entity(name = "OPTIONZ") // option, options는 에약어
 public class Option {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long optionsId;
+  @Column(nullable = false)
   private String name;
+  @Column(nullable = false)
   private int price;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "group_id")
+  private Group group;
 
   @Builder
-  private Option(String name, int price) {
+  private Option(String name, int price, Group group) {
     this.name = name;
     this.price = price;
+    this.group = group;
   }
 }

--- a/src/main/java/com/godsang/anytimedelivery/menu/mapper/MenuMapper.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/mapper/MenuMapper.java
@@ -12,17 +12,17 @@ import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface MenuMapper {
-  Option optionDtoToOption(OptionDto optionDto);
+  Option optionDtoToOption(OptionDto.Post optionDto);
 
-  List<Option> optionDtosToOptions(List<OptionDto> optionDtos);
+  List<Option> optionDtosToOptions(List<OptionDto.Post> optionDtos);
 
   Group groupDtoToGroup(GroupDto.Post groupDto);
 
   Menu menuDtoToMenu(MenuDto.Post menuDto);
 
-  OptionDto optionToOptionDto(Option option);
+  OptionDto.Response optionToOptionDto(Option option);
 
-  List<OptionDto> optionsToOptionDtos(List<Option> options);
+  List<OptionDto.Response> optionsToOptionDtos(List<Option> options);
 
   GroupDto.Response groupToGroupDto(Group group);
 

--- a/src/main/java/com/godsang/anytimedelivery/menu/mapper/MenuMapper.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/mapper/MenuMapper.java
@@ -18,6 +18,8 @@ public interface MenuMapper {
 
   Group groupDtoToGroup(GroupDto.Post groupDto);
 
+  List<Group> groupDtosToGroups(List<GroupDto.Post> groupDtos);
+
   Menu menuDtoToMenu(MenuDto.Post menuDto);
 
   OptionDto.Response optionToOptionDto(Option option);
@@ -26,5 +28,17 @@ public interface MenuMapper {
 
   GroupDto.Response groupToGroupDto(Group group);
 
+  List<GroupDto.Response> groupsToGroupDtos(List<Group> group);
+
   MenuDto.Response menuToMenuDto(Menu menu);
+
+  default Menu bidirectionalMapping(Menu menu) {
+    for (Group group : menu.getGroups()) {
+      group.setMenu(menu);
+      for (Option option : group.getOptions()) {
+        option.setGroup(group);
+      }
+    }
+    return menu;
+  }
 }

--- a/src/main/java/com/godsang/anytimedelivery/menu/service/MenuService.java
+++ b/src/main/java/com/godsang/anytimedelivery/menu/service/MenuService.java
@@ -30,14 +30,12 @@ public class MenuService {
    * @Return Menu
    */
   @Transactional
-  public Menu createMenu(long storeId, Menu menu, Group group) {
+  public Menu createMenu(long storeId, Menu menu) {
     Store store = storeService.findStoreById(storeId);
     verifyStoreOwner(store);
     verifyStoreHasSameMenu(store, menu.getName());
 
     menu.setStore(store);
-    menu.addGroup(group);
-    group.setMenu(menu);
     return menuRepository.save(menu);
   }
 

--- a/src/test/java/com/godsang/anytimedelivery/helper/StubData.java
+++ b/src/test/java/com/godsang/anytimedelivery/helper/StubData.java
@@ -19,6 +19,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public class StubData {
@@ -154,6 +155,34 @@ public class StubData {
           .group(group)
           .build();
     }
+
+    public static List<Option> getOptionList(Group group) {
+      List<Option> options = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        Option option = getOption("매운맛" + i, 1000, group);
+        options.add(option);
+      }
+      return options;
+    }
+
+    public static List<Group> getGroupList(Menu menu) {
+      List<Group> groups = new ArrayList<>();
+      for (int i = 0; i < 5; i++) {
+        Group group = getMockGroupEntity("맛 선택", "radio");
+        List<Option> options = getOptionList(group);
+        group.setOptions(options);
+        group.setMenu(menu);
+        groups.add(group);
+      }
+      return groups;
+    }
+
+    public static Menu getMockMenuEntity() {
+      Menu menu = getMockMenuEntity("떡볶이", 10000);
+      List<Group> groups = getGroupList(menu);
+      menu.setGroups(groups);
+      return menu;
+    }
   }
 
 
@@ -163,6 +192,24 @@ public class StubData {
       super.setName(name);
       super.setPrice(price);
       super.setGroups(groups);
+    }
+    public static MenuDto.Post getMenuDto(String name, int price, List<GroupDto.Post> groups) {
+      MenuDto.Post post = new MenuDto.Post();
+      post.setName(name);
+      post.setPrice(price);
+      post.setDescription("설명입니다.");
+      post.setPhoto("사진");
+      post.setGroups(groups);
+      return post;
+    }
+    public static MenuDto.Post getMenuDto() {
+      MenuDto.Post post = new MenuDto.Post();
+      post.setName("떡볶이");
+      post.setPrice(10000);
+      post.setDescription("설명입니다.");
+      post.setPhoto("사진");
+      post.setGroups(getGroupDtoList());
+      return post;
     }
 
     public static GroupDto.Post getGroupDto(String title, String choiceType, List<OptionDto.Post> optionDtos) {
@@ -178,6 +225,24 @@ public class StubData {
       optionPostDto.setName(name);
       optionPostDto.setPrice(price);
       return optionPostDto;
+    }
+
+    public static List<OptionDto.Post> getOptionDtoList() {
+      List<OptionDto.Post> posts = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        posts.add(StubData.MockMenuPost.getOptionDto("착한맛" + i, 1000));
+      }
+      return posts;
+    }
+
+    public static List<GroupDto.Post> getGroupDtoList() {
+      List<GroupDto.Post> posts = new ArrayList<>();
+      for (int i = 0; i < 5; i++) {
+        List<OptionDto.Post> optionPostDtos = StubData.MockMenuPost.getOptionDtoList();
+        GroupDto.Post post = StubData.MockMenuPost.getGroupDto("맛 선택" + i, "radio", optionPostDtos);
+        posts.add(post);
+      }
+      return posts;
     }
   }
 }

--- a/src/test/java/com/godsang/anytimedelivery/helper/StubData.java
+++ b/src/test/java/com/godsang/anytimedelivery/helper/StubData.java
@@ -1,8 +1,6 @@
 package com.godsang.anytimedelivery.helper;
 
 
-import com.godsang.anytimedelivery.deliveryArea.entity.DeliveryArea;
-import com.godsang.anytimedelivery.store.dto.StoreDto;
 import com.godsang.anytimedelivery.address.dto.AddressDto;
 import com.godsang.anytimedelivery.address.entity.Address;
 import com.godsang.anytimedelivery.menu.dto.GroupDto;
@@ -142,18 +140,18 @@ public class StubData {
           .build();
     }
 
-    public static Group getMockGroupEntity(String title, String choiceType, List<Option> options) {
+    public static Group getMockGroupEntity(String title, String choiceType) {
       return Group.builder()
           .title(title)
           .choiceType(choiceType)
-          .options(options)
           .build();
     }
 
-    public static Option getOption(String name, int price) {
+    public static Option getOption(String name, int price, Group group) {
       return Option.builder()
           .name(name)
           .price(price)
+          .group(group)
           .build();
     }
   }
@@ -167,7 +165,7 @@ public class StubData {
       super.setGroups(groups);
     }
 
-    public static GroupDto.Post getGroupDto(String title, String choiceType, List<OptionDto> optionDtos) {
+    public static GroupDto.Post getGroupDto(String title, String choiceType, List<OptionDto.Post> optionDtos) {
       GroupDto.Post groupDto = new GroupDto.Post();
       groupDto.setTitle(title);
       groupDto.setChoiceType(choiceType);
@@ -175,11 +173,11 @@ public class StubData {
       return groupDto;
     }
 
-    public static OptionDto getOptionDto(String name, int price) {
-      OptionDto optionDto = new OptionDto();
-      optionDto.setName(name);
-      optionDto.setPrice(price);
-      return optionDto;
+    public static OptionDto.Post getOptionDto(String name, int price) {
+      OptionDto.Post optionPostDto = new OptionDto.Post();
+      optionPostDto.setName(name);
+      optionPostDto.setPrice(price);
+      return optionPostDto;
     }
   }
 }

--- a/src/test/java/com/godsang/anytimedelivery/menu/MenuIntegrationTest.java
+++ b/src/test/java/com/godsang/anytimedelivery/menu/MenuIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.godsang.anytimedelivery.menu;
 
-import com.godsang.anytimedelivery.deliveryArea.entity.DeliveryArea;
 import com.godsang.anytimedelivery.helper.StubData;
 import com.godsang.anytimedelivery.menu.dto.MenuDto;
 import com.godsang.anytimedelivery.menu.entity.Menu;
@@ -18,15 +17,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.Cookie;
-
-import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -67,7 +62,7 @@ public class MenuIntegrationTest {
     savedAddress = "서울특별시 강남구 강남대로 123길 12";
     Store store = StubData.MockStore.getMockEntity(1L, savedRegistrationNumber, savedName, savedTel, savedAddress);
     store.setUser(savedUser);
-    Store savedStore =  storeRepository.save(store);
+    Store savedStore = storeRepository.save(store);
     storeId = savedStore.getStoreId();
 
 
@@ -79,6 +74,7 @@ public class MenuIntegrationTest {
         )
         .andReturn().getResponse().getCookie("SESSION");
   }
+
   @Test
   @DisplayName("가게등록 성공")
   void createStoreTest() throws Exception {

--- a/src/test/java/com/godsang/anytimedelivery/menu/MenuIntegrationTest.java
+++ b/src/test/java/com/godsang/anytimedelivery/menu/MenuIntegrationTest.java
@@ -1,0 +1,113 @@
+package com.godsang.anytimedelivery.menu;
+
+import com.godsang.anytimedelivery.deliveryArea.entity.DeliveryArea;
+import com.godsang.anytimedelivery.helper.StubData;
+import com.godsang.anytimedelivery.menu.dto.MenuDto;
+import com.godsang.anytimedelivery.menu.entity.Menu;
+import com.godsang.anytimedelivery.menu.repository.MenuRepository;
+import com.godsang.anytimedelivery.store.entity.Store;
+import com.godsang.anytimedelivery.store.repository.StoreRepository;
+import com.godsang.anytimedelivery.user.entity.Role;
+import com.godsang.anytimedelivery.user.entity.User;
+import com.godsang.anytimedelivery.user.service.UserService;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.Cookie;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
+public class MenuIntegrationTest {
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private Gson gson;
+  @Autowired
+  private UserService userService;
+  @Autowired
+  private StoreRepository storeRepository;
+  @Autowired
+  private MenuRepository menuRepository;
+  private String savedRegistrationNumber;
+  private String savedName;
+  private String savedTel;
+  private String savedAddress;
+  private Cookie session;
+  private Long storeId;
+
+  @BeforeAll
+  void saveEntity() throws Exception {
+    User user = StubData.MockUser.getMockEntity(Role.ROLE_OWNER);
+    String password = user.getPassword();
+    User savedUser = userService.createUser(user, "owner");
+
+    savedRegistrationNumber = "123-12-12345";
+    savedName = "애니타임 치킨";
+    savedTel = "02-1234-5678";
+    savedAddress = "서울특별시 강남구 강남대로 123길 12";
+    Store store = StubData.MockStore.getMockEntity(1L, savedRegistrationNumber, savedName, savedTel, savedAddress);
+    store.setUser(savedUser);
+    Store savedStore =  storeRepository.save(store);
+    storeId = savedStore.getStoreId();
+
+
+    session = mockMvc.perform(
+            post("/users/login")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .param("email", user.getEmail())
+                .param("password", password)
+        )
+        .andReturn().getResponse().getCookie("SESSION");
+  }
+  @Test
+  @DisplayName("가게등록 성공")
+  void createStoreTest() throws Exception {
+    // given
+    String registrationNumber = "321-21-54321";
+    String name = "오빠닥";
+    String tel = "031-123-1234";
+    String address = "경기도 성남시 분당구 정자동 123";
+    MenuDto.Post post = StubData.MockMenuPost.getMenuDto();
+    String content = gson.toJson(post);
+
+    // when
+    mockMvc.perform(
+            post("/owner/stores/" + storeId)
+                .cookie(session)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+        )
+        // then
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.data.name").value(post.getName()))
+        .andExpect(jsonPath("$.data.groups[0].title").value(post.getGroups().get(0).getTitle()))
+        .andExpect(jsonPath("$.data.groups[0].options[0].name").value(post.getGroups().get(0).getOptions().get(0).getName()));
+
+    Menu menu = menuRepository.findById(1L).get();
+    assertThat(menu.getStore().getStoreId()).isEqualTo(storeId);
+
+    String optionName = menu.getGroups().get(0).getOptions().get(0).getName();
+    assertThat(optionName).isEqualTo(post.getGroups().get(0).getOptions().get(0).getName());
+  }
+}

--- a/src/test/java/com/godsang/anytimedelivery/menu/MenuMapperTest.java
+++ b/src/test/java/com/godsang/anytimedelivery/menu/MenuMapperTest.java
@@ -1,0 +1,182 @@
+package com.godsang.anytimedelivery.menu;
+
+import com.godsang.anytimedelivery.helper.StubData;
+import com.godsang.anytimedelivery.menu.dto.GroupDto;
+import com.godsang.anytimedelivery.menu.dto.MenuDto;
+import com.godsang.anytimedelivery.menu.dto.OptionDto;
+import com.godsang.anytimedelivery.menu.entity.Group;
+import com.godsang.anytimedelivery.menu.entity.Menu;
+import com.godsang.anytimedelivery.menu.entity.Option;
+import com.godsang.anytimedelivery.menu.mapper.MenuMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+public class MenuMapperTest {
+  @Autowired
+  private MenuMapper menuMapper;
+
+  @Test
+  void optionDtoToOptionTest() {
+    //given
+    OptionDto.Post optionPostDto = StubData.MockMenuPost.getOptionDto("착한맛", 1000);
+
+    //when
+    Option option = menuMapper.optionDtoToOption(optionPostDto);
+
+    //then
+    assertThat(option.getName()).isEqualTo(optionPostDto.getName());
+  }
+
+  @Test
+  void optionDtosToOptionsTest() {
+    //given
+    List<OptionDto.Post> posts = StubData.MockMenuPost.getOptionDtoList();
+
+    //when
+    List<Option> options = menuMapper.optionDtosToOptions(posts);
+
+    //then
+    assertThat(options.get(9).getName())
+        .isEqualTo(posts.get(9).getName());
+  }
+
+  @Test
+  void groupDtoToGroupTest() {
+    //given
+    List<OptionDto.Post> optionPostDtos = StubData.MockMenuPost.getOptionDtoList();
+    GroupDto.Post post = StubData.MockMenuPost.getGroupDto("맛 선택", "radio", optionPostDtos);
+
+    //when
+    Group group = menuMapper.groupDtoToGroup(post);
+
+    //then
+    assertThat(group.getOptions().get(9).getName())
+        .isEqualTo(optionPostDtos.get(9).getName());
+    assertThat(group.getTitle())
+        .isEqualTo(post.getTitle());
+  }
+
+  @Test
+  void groupDtosToGroupsTest() {
+    //given
+    List<GroupDto.Post> posts = StubData.MockMenuPost.getGroupDtoList();
+
+    //when
+    List<Group> groups = menuMapper.groupDtosToGroups(posts);
+
+    //then
+    assertThat(groups.get(4).getTitle()).isEqualTo(posts.get(4).getTitle());
+    assertThat(groups.get(4).getOptions().get(9).getName())
+        .isEqualTo(posts.get(4).getOptions().get(9).getName());
+  }
+
+  @Test
+  void menuDtoToMenuTest() {
+    //given
+    List<GroupDto.Post> groupDtos = StubData.MockMenuPost.getGroupDtoList();
+    MenuDto.Post post = StubData.MockMenuPost.getMenuDto("떡볶이", 10000, groupDtos);
+
+    //when
+    Menu menu = menuMapper.menuDtoToMenu(post);
+
+    //then
+    assertThat(menu.getName()).isEqualTo(post.getName());
+    assertThat(menu.getGroups().get(4).getTitle()).isEqualTo(groupDtos.get(4).getTitle());
+    assertThat(menu.getGroups().get(4).getOptions().get(9).getName())
+        .isEqualTo(groupDtos.get(4).getOptions().get(9).getName());
+  }
+
+  @Test
+  void optionToOptionDtoTest() {
+    //given
+    Group group = StubData.MockMenu.getMockGroupEntity("맛 선택", "radio");
+    Option option = StubData.MockMenu.getOption("매운맛", 1000, group);
+
+    //when
+    OptionDto.Response response = menuMapper.optionToOptionDto(option);
+
+    //then
+    assertThat(response.getName()).isEqualTo(option.getName());
+  }
+
+  @Test
+  void optionsToOptionDtosTest() {
+    //given
+    Group group = StubData.MockMenu.getMockGroupEntity("맛 선택", "radio");
+    List<Option> options = StubData.MockMenu.getOptionList(group);
+
+    //when
+    List<OptionDto.Response> responses = menuMapper.optionsToOptionDtos(options);
+
+    //when
+    assertThat(responses.get(9).getName())
+        .isEqualTo(options.get(9).getName());
+  }
+
+  @Test
+  void groupToGroupDtoTest() {
+    //given
+    Menu menu = StubData.MockMenu.getMockMenuEntity("떡볶이", 10000);
+    Group group = StubData.MockMenu.getMockGroupEntity("맛 선택", "radio");
+    group.getMenu();
+    group.setOptions(StubData.MockMenu.getOptionList(group));
+
+    //when
+    GroupDto.Response response = menuMapper.groupToGroupDto(group);
+
+    //then
+    assertThat(response.getTitle()).isEqualTo(group.getTitle());
+    assertThat(response.getOptions().get(9).getName())
+        .isEqualTo(group.getOptions().get(9).getName());
+  }
+
+  @Test
+  void groupsToGroupDtosTest() {
+    //given
+    Menu menu = StubData.MockMenu.getMockMenuEntity("떡볶이", 10000);
+    List<Group> groups = StubData.MockMenu.getGroupList(menu);
+
+    //when
+    List<GroupDto.Response> responses = menuMapper.groupsToGroupDtos(groups);
+
+    //then
+    assertThat(responses.get(4).getTitle()).isEqualTo(groups.get(4).getTitle());
+    assertThat(responses.get(4).getOptions().get(9).getName())
+        .isEqualTo(groups.get(4).getOptions().get(9).getName());
+  }
+
+  @Test
+  void menuToMenuDtoTest() {
+    //given
+    Menu menu = StubData.MockMenu.getMockMenuEntity();
+
+    //when
+    MenuDto.Response response = menuMapper.menuToMenuDto(menu);
+
+    //then
+    assertThat(response.getName()).isEqualTo(menu.getName());
+    assertThat(response.getGroups().get(4).getTitle()).isEqualTo(menu.getGroups().get(4).getTitle());
+    assertThat(response.getGroups().get(4).getOptions().get(9).getName())
+        .isEqualTo(menu.getGroups().get(4).getOptions().get(9).getName());
+  }
+
+  @Test
+  void bidirectionalMappingTest() {
+    //given
+    Menu uniDirectionalMenu = menuMapper.menuDtoToMenu(StubData.MockMenuPost.getMenuDto());
+
+    //when
+    Menu bidirectionalMenu = menuMapper.bidirectionalMapping(uniDirectionalMenu);
+
+    //then
+    assertThat(bidirectionalMenu.getGroups().get(0).getMenu()).isNotNull();
+    assertThat(bidirectionalMenu.getGroups().get(0).getOptions().get(0).getGroup()).isNotNull();
+  }
+
+}

--- a/src/test/java/com/godsang/anytimedelivery/menu/MenuRepositoryTest.java
+++ b/src/test/java/com/godsang/anytimedelivery/menu/MenuRepositoryTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,16 +39,17 @@ public class MenuRepositoryTest {
     Store store = StubData.MockStore.getMockEntity(1L, registrationNumber, "애니타임 치킨", "02-123-1234", "서울특별시 강남구 강남대로 123");
     storeRepository.save(store);
 
+    Menu menu = StubData.MockMenu.getMockMenuEntity("푸다닥 치킨", 30000);
+    Group group = StubData.MockMenu.getMockGroupEntity(title, choiceType);
     List<Option> options = new ArrayList<>();
     for (int i = 0; i < optionName.length; i++) {
-      options.add(StubData.MockMenu.getOption(optionName[i], 5000));
+      options.add(StubData.MockMenu.getOption(optionName[i], 5000, group));
     }
-    Group group = StubData.MockMenu.getMockGroupEntity(title, choiceType, options);
-    Menu menu = StubData.MockMenu.getMockMenuEntity("푸다닥 치킨", 30000);
-    menu.addGroup(group);
-    menu.setStore(store);
     group.setMenu(menu);
+    menu.setStore(store);
 
+    menu.addGroup(group);
+    group.setOptions(options);
     menuRepository.save(menu);
   }
 


### PR DESCRIPTION
cascade 활용해서 entity저장하는데에서 좀 막혔는데, JPA는 항상 연관관계의 주인을 바라본다고해요. 그래서 저장할 때,

Option <-> Group <-> Menu -> Store

위에처럼 서로가 서로를 가지고 있어야, Menu 객체를 저장하면 한번에 잘 저장이 됩니다!